### PR TITLE
290/390-p06-typo (Yumin corrects himself)

### DIFF
--- a/08-projects.Rmd
+++ b/08-projects.Rmd
@@ -3500,7 +3500,7 @@ An example from 1987 data can be found [here](https://www.datadepot.rcac.purdue.
 
 **Important note:** Please make sure to look at your knit PDF *before* submitting. PDFs should be relatively short and not contain huge amounts of printed data. Remember you can use functions like `head` to print a sample of the data or output. Extremely large PDFs will be subject to lose points.
 
-##### 1. In previous projects we learned how to get a single column of data from a csv file. Write 1 line of UNIX commands to print the 17th column, the `ORIGIN`, from `1987.csv`. Write another line, this time using `awk` to do the same thing. Which one do you prefer, and why?
+##### 1. In previous projects we learned how to get a single column of data from a csv file. Write 1 line of UNIX commands to print the 17th column, the `Origin`, from `1987.csv`. Write another line, this time using `awk` to do the same thing. Which one do you prefer, and why?
 
 **Relevant topics:** [cut](#cut), [awk](#awk)
 
@@ -3573,7 +3573,7 @@ And although we aren't running the code chunk above, we know that it works becau
 - The number of flights that arrived at Indianapolis (IND) in 2008.
 ```
 
-##### 4. Do you expect the number of unique origins and destinations to be the same based on flight data in the year 2008? Find out, using any command line tool you'd like. Are they indeed the same? How many unique values do we have per category (`ORIGIN`, `DEST`)?
+##### 4. Do you expect the number of unique origins and destinations to be the same based on flight data in the year 2008? Find out, using any command line tool you'd like. Are they indeed the same? How many unique values do we have per category (`Origin`, `Dest`)?
 
 **Relevant topics:** [cut](#cut), [sort](#sort), [uniq](#uniq), [wc](#wc), [awk](#awk)
 
@@ -3582,10 +3582,10 @@ And although we aren't running the code chunk above, we know that it works becau
 
 - 1-2 sentences explaining whether or not you expect the number of unique origins and destinations to be the same.
 - The UNIX command(s) used to figure out if the number of unique origins and destinations are the same. 
-- The number of unique values per category (`ORIGIN`, `DEST`).
+- The number of unique values per category (`Origin`, `Dest`).
 ```
 
-##### 5. In (4) we found that there are not the same number of unique `ORIGIN`'s as `DEST`'s. Find the [IATA airport code](https://en.wikipedia.org/wiki/International_Air_Transport_Association_code#Airport_codes) for all `ORIGIN`'s that don't appear in a `DEST` and all `DEST`'s that don't appear in an `ORIGIN` in the 2008 data.
+##### 5. In (4) we found that there are not the same number of unique `Origin`'s as `Dest`'s. Find the [IATA airport code](https://en.wikipedia.org/wiki/International_Air_Transport_Association_code#Airport_codes) for all `Origin`'s that don't appear in a `Dest` and all `Dest`'s that don't appear in an `Origin` in the 2008 data.
 
 **Hint:** The examples on [this](https://www.tutorialspoint.com/unix_commands/comm.htm) page should help. Note that these examples are based on [Process Substitution](https://tldp.org/LDP/abs/html/process-sub.html), which basically allows you to specify commands whose output would be used as the input of `comm`. There should be no space between `<` and `(`, otherwise your bash will not work as intended.
 
@@ -3595,21 +3595,21 @@ And although we aren't running the code chunk above, we know that it works becau
 **Item(s) to submit:**
 
 - The line(s) of UNIX command(s) used to answer the question.
-- The list of `ORIGIN`s that don't appear in `DEST`.
-- The list of `DEST`s that don't appear in `ORIGIN`.
+- The list of `Origin`s that don't appear in `Dest`.
+- The list of `Dest`s that don't appear in `Origin`.
 ```
 
 
-##### 6. What was the average number of flights in 2008 per unique `ORIGIN` with the `DEST` of "IND"? How does "PHX" (as a unique `ORIGIN`) compare to the average?
+##### 6. What was the average number of flights in 2008 per unique `Origin` with the `Dest` of "IND"? How does "PHX" (as a unique `Origin`) compare to the average?
 
-**Hint:** You manually do the average calculation by dividing the result from (3) by the number of unique `ORIGIN`'s that have a `DEST` of "IND".
+**Hint:** You manually do the average calculation by dividing the result from (3) by the number of unique `Origin`'s that have a `Dest` of "IND".
 
 **Relevant topics:** [awk](#awk), [sort](#sort), [grep](#grep), [wc](#wc)
 
 ```{block, type="bbox"}
 **Item(s) to submit:**
 
-- The average number of flights in 2008 per unique `ORIGIN` with the `DEST` of "IND".
+- The average number of flights in 2008 per unique `Origin` with the `Dest` of "IND".
 - 1-2 sentences explaining how "PHX" compares (as a unique `ORIGIN`) to the average?
 ```
 
@@ -6059,7 +6059,7 @@ An example from 1987 data can be found [here](https://www.datadepot.rcac.purdue.
 
 #### Questions
 
-##### 1. In previous projects we learned how to get a single column of data from a csv file. Write 1 line of UNIX commands to print the 17th column, the `ORIGIN`, from `1987.csv`. Write another line, this time using `awk` to do the same thing. Which one do you prefer, and why?
+##### 1. In previous projects we learned how to get a single column of data from a csv file. Write 1 line of UNIX commands to print the 17th column, the `Origin`, from `1987.csv`. Write another line, this time using `awk` to do the same thing. Which one do you prefer, and why?
 
 **Relevant topics:** [cut](#cut), [awk](#awk)
 
@@ -6132,7 +6132,7 @@ And although we aren't running the code chunk above, we know that it works becau
 - The number of flights that arrived at Indianapolis (IND) in 2008.
 ```
 
-##### 4. Do you expect the number of unique origins and destinations to be the same based on flight data in the year 2008? Find out, using any command line tool you'd like. Are they indeed the same? How many unique values do we have per category (`ORIGIN`, `DEST`)?
+##### 4. Do you expect the number of unique origins and destinations to be the same based on flight data in the year 2008? Find out, using any command line tool you'd like. Are they indeed the same? How many unique values do we have per category (`Origin`, `Dest`)?
 
 **Relevant topics:** [cut](#cut), [sort](#sort), [uniq](#uniq), [wc](#wc), [awk](#awk)
 
@@ -6141,10 +6141,10 @@ And although we aren't running the code chunk above, we know that it works becau
 
 - 1-2 sentences explaining whether or not you expect the number of unique origins and destinations to be the same.
 - The UNIX command(s) used to figure out if the number of unique origins and destinations are the same. 
-- The number of unique values per category (`ORIGIN`, `DEST`).
+- The number of unique values per category (`Origin`, `Dest`).
 ```
 
-##### 5. In (4) we found that there are not the same number of unique `ORIGIN`'s as `DEST`'s. Find the [IATA airport code](https://en.wikipedia.org/wiki/International_Air_Transport_Association_code#Airport_codes) for all `ORIGIN`'s that don't appear in a `DEST` and all `DEST`'s that don't appear in an `ORIGIN` in the 2008 data.
+##### 5. In (4) we found that there are not the same number of unique `Origin`'s as `Dest`'s. Find the [IATA airport code](https://en.wikipedia.org/wiki/International_Air_Transport_Association_code#Airport_codes) for all `Origin`'s that don't appear in a `Dest` and all `Dest`'s that don't appear in an `Origin` in the 2008 data.
 
 **Hint:** The examples on [this](https://www.tutorialspoint.com/unix_commands/comm.htm) page should help. Note that these examples are based on [Process Substitution](https://tldp.org/LDP/abs/html/process-sub.html), which basically allows you to specify commands whose output would be used as the input of `comm`. There should be no space between `<` and `(`, otherwise your bash will not work as intended.
 
@@ -6154,21 +6154,21 @@ And although we aren't running the code chunk above, we know that it works becau
 **Item(s) to submit:**
 
 - The line(s) of UNIX command(s) used to answer the question.
-- The list of `ORIGIN`s that don't appear in `DEST`.
-- The list of `DEST`s that don't appear in `ORIGIN`.
+- The list of `Origin`s that don't appear in `Dest`.
+- The list of `Dest`s that don't appear in `Origin`.
 ```
 
-##### 6. What was the average number of flights in 2008 per unique `ORIGIN` with the `DEST` of "IND"? How does "PHX" (as a unique `ORIGIN`) compare to the average?
+##### 6. What was the average number of flights in 2008 per unique `Origin` with the `Dest` of "IND"? How does "PHX" (as a unique `Origin`) compare to the average?
 
-**Hint:** You manually do the average calculation by dividing the result from (3) by the number of unique `ORIGIN`'s that have a `DEST` of "IND".
+**Hint:** You manually do the average calculation by dividing the result from (3) by the number of unique `Origin`'s that have a `Dest` of "IND".
 
 **Relevant topics:** [awk](#awk), [sort](#sort), [grep](#grep), [wc](#wc)
 
 ```{block, type="bbox"}
 **Item(s) to submit:**
 
-- The average number of flights in 2008 per unique `ORIGIN` with the `DEST` of "IND".
-- 1-2 sentences explaining how "PHX" compares (as a unique `ORIGIN`) to the average?
+- The average number of flights in 2008 per unique `ORIGIN` with the `Dest` of "IND".
+- 1-2 sentences explaining how "PHX" compares (as a unique `Origin`) to the average?
 ```
 
 ##### 7. Write a bash script that takes a year and IATA airport code and returns the year, and the total number of flights to and from the given airport. Example rows may look like:


### PR DESCRIPTION
Dear @kevinamstutz , I am creating this pull request to correct the typos that I introduced previously in #80 . 

When making the previous modification, I was assuming that the data files are under `/class/datamine/data/flights`. The variable names are all capitalized there. However, you already pointed out that we should use `/class/datamine/data/flights/subset`, where only the first letters in variable names are capitalized. 

Sorry for bringing this extra trouble! 