### PR TITLE
Fix markdown table formatting in SQL example

### DIFF
--- a/03-sql.Rmd
+++ b/03-sql.Rmd
@@ -103,7 +103,7 @@ SELECT orders.description, orders.value, customers.email FROM orders LEFT JOIN c
 Which would result in the following table, enabling the employee to see orders as well as send out thank you emails.
 
 |description|value|first_name|last_name|email|
-|-----------|----:|
+|-----------|----:|----------|---------|-----|
 |Water bottle|15.00|Natalie|Wright|wright@example.com|
 |Key chain|7.50|Natalie|Wright|wright@example.com|
 |Computer|2000.00|Ben|Schwartz|schwartz@example.com|
@@ -119,7 +119,7 @@ SELECT orders.description, orders.value, customers.email FROM orders INNER JOIN 
 ```
 
 |description|value|first_name|last_name|email|
-|-----------|----:|
+|-----------|----:|----------|---------|-----|
 |Water bottle|15.00|Natalie|Wright|wright@example.com|
 |Key chain|7.50|Natalie|Wright|wright@example.com|
 |Computer|2000.00|Ben|Schwartz|schwartz@example.com|


### PR DESCRIPTION
There was a typo in the markdown that was causing tables to not show all the columns. (This is my first time contributing changes to the Examples Book, I hope I'm doing everything correctly.)