### PR TITLE
Update links to all examples sections

### DIFF
--- a/02-data-formats.Rmd
+++ b/02-data-formats.Rmd
@@ -266,7 +266,7 @@ In order to make comparisons, we need operators. The following is a list of xpat
 
 xpath functions are an easy way to filter data with more control. You can find a list of functions [here](https://developer.mozilla.org/en-US/docs/Web/XPath/Functions). Of particular use are the `contains` and `translate` functions. `contains` allows you to see if the first argument string contains the second argument string. It is particularly useful to see if a class or attribute contains some substring. `translate` allows you to, among other things, change the case of some text prior to using the `contains` function, for example. 
 
-#### Examples
+#### Examples {#data-format-xml-xpath-examples}
 
 Given the following XML, answer the questions.
 

--- a/03-unix.Rmd
+++ b/03-unix.Rmd
@@ -155,7 +155,7 @@ ls -l -a /home/$USER/projects
 
 `du` is a tool used to get file space usage.
 
-#### Examples
+#### Examples {#unix-utility-du-examples}
 
 ##### How do I get the size of a file called `./metadata.csv` in bytes?
 
@@ -236,7 +236,7 @@ mv ../some_file.txt .
 
 `mkdir` is the command to create a directory. It is simple to use, just type `mkdir` followed by a path to the new directory.
 
-#### Examples
+#### Examples {#unix-utility-mkdir-examples}
 
 ##### How do I create a new directory called `my_directory` in the current directory?
 
@@ -275,7 +275,7 @@ mkdir -p first_dir/second_dir
 
 `rm` is the command to remove files or directories. You can find the available options by checking its [manual page](#man). 
 
-#### Examples
+#### Examples {#unix-utility-rm-examples}
 
 ##### How do I remove a folder called `my_folder` and all of its contents recursively. Assume `my_folder` is in `/home/user/projects`.
 
@@ -643,7 +643,7 @@ rg -L foo my_directory
 
 `find` is an aptly named tool that traverses directories and searches for files.
 
-#### Examples
+#### Examples {#unix-utility-find-examples}
 
 ##### How do I find a file named `foo.txt` in the current working directory or subdirectories?
 
@@ -734,7 +734,7 @@ Press the "q" key on your keyboard.
 
 `sort` is a utility that sorts lines of text.
 
-#### Examples
+#### Examples {#unix-utility-sort-examples}
 
 ##### How do I sort a csv, `flights_sample.csv` alphabetically by the 18th column?
 
@@ -793,7 +793,7 @@ head 5000_products.csv | awk -F, '{print $3}'
 
 `awk` has some special built in variables that can be very useful. See [here](https://www.thegeekstuff.com/2010/01/8-powerful-awk-built-in-variables-fs-ofs-rs-ors-nr-nf-filename-fnr/).
 
-### Examples
+### Examples {#unix-awk-examples}
 
 ##### How do I print only rows where the `DAYOFWEEK` is `5`?
 
@@ -881,7 +881,7 @@ cat metadata.csv | awk -F, '{seasons[$8]++}END{for (season in seasons) {if (seas
 
 `..` represents the parent directory. For example, `/home` is the parent directory of `/home/$USER`. If you are currently in `/home/$USER/projects` and you want to access some file in the home directory, you could do `../some_file.txt`. `../some_file.txt` is called a _relative_ path as it is _relative_ to your current location. If we accessed `../some_file.txt` from the home directory, this would be different than accessing `../some_file.txt` from a different directory. `/home/$USER/some_file.txt` is an _absolute_ or _full_ path of a file `some_file.txt`. 
 
-### Examples
+### Examples {#unix-special-directory-examples}
 
 #### If I am in the directory `/home/kamstut/projects` directory, what is the _relative_ path to `/home/mdw/`?
 <details>
@@ -918,7 +918,7 @@ Piping is a form of redirection, but rather than redirect output to stdin, stdou
 
 ### Redirection 
 
-#### Examples
+#### Examples {#unix-redirection-examples}
 
 For the following examples we use the example file `redirection.txt`. The contents of which are:
 
@@ -996,7 +996,7 @@ head value.txt
 
 Piping is the act of taking the output of one or more commands and making the output the input of another command. This is accomplished using the "|" character.
 
-#### Examples
+#### Examples {#unix-piping-examples}
 
 For the following examples we use the example file `piping.txt`. The contents of which are:
 

--- a/05-r.Rmd
+++ b/05-r.Rmd
@@ -449,7 +449,7 @@ Operator | Description
 `x|y`    | x OR y
 `x&y`    | x AND y
 
-### Examples
+### Examples {#r-logical-operators-examples}
 
 #### What are the values in a vector, `vec` that are greater than 5?
 
@@ -694,7 +694,7 @@ my_vec[c("alpha", "charlie")]
 my_list[c("alpha", "charlie")]
 ```
 
-#### Examples
+#### Examples {#r-lists-vectors-indexing-examples}
 
 ##### How can I get the first 2 values of a vector named `my_vec`?
 
@@ -749,7 +749,7 @@ my_vec[c('otter','dog')]
 
 Often operations in `R` on two or more vectors require them to be the same length. When `R` encounters vectors with different lengths, it automatically repeats (recycles) the shorter vector until the length of the vectors is the same.
 
-### Examples
+### Examples {#r-lists-vectors-examples}
 
 #### Given two numeric vectors with different lengths, add them element-wise.
 
@@ -768,7 +768,7 @@ x+y
 
 `all` returns a logical value (`TRUE` or `FALSE`) if all values in a vector are `TRUE`.
 
-#### Examples
+#### Examples {#r-basic-all-examples}
 
 ##### Are all values in `x` positive?
 
@@ -784,7 +784,7 @@ all(x>0) # FALSE
 
 `any` returns a logical value (`TRUE` or `FALSE`) if any values in a vector are `TRUE`.
 
-#### Examples
+#### Examples {#r-basic-any-examples}
 
 ##### Are any values in `x` positive?
 
@@ -800,7 +800,7 @@ any(x>0) # TRUE
 
 `all.equal` compares two objects and tests if they are "nearly equal" (up to some provided tolerance).
 
-#### Examples
+#### Examples {#r-basic-all.equal-examples}
 
 ##### Is $\pi$ equal to 3.14?
 
@@ -838,7 +838,7 @@ Although `%in%` doesn't look like it, it is a function. Given two vectors, `%in%
 
 You can learn more about `%in%` by running `?"%in%"`. 
 
-#### Examples
+#### Examples {#r-basic-in-examples}
 
 ##### How do I find whether or not a value, `5` is in a given vector?
 
@@ -870,7 +870,7 @@ Given two vectors, the function `setdiff` returns the element of the first vecto
 **Note:** The order in which the vectors are listed in relation to the function `setdiff` matters, as illustrated in the first two examples.
 
 
-#### Examples
+#### Examples {#r-basic-setdiff-examples}
 
 ##### Let `x = (a, b, b, c)` and `y = (c, b, d, e, f)`. How to I find the elements in vector `x` that are not in vector `y`?
 
@@ -901,7 +901,7 @@ The `intersect` function returns the elements that two vectors or data.frames ha
 **Note:** The order in which the vectors are listed in relation to the function `intersect` only affects the order of the common elements returned.
 
 
-#### Examples
+#### Examples {#r-basic-intersect-examples}
 
 ##### Let `x = (a, b, b, c)` and `y = (c, b, d, e, f)`. How to I find the elements shared both by vector `x` and by vector `y`?
 
@@ -923,7 +923,7 @@ intersect(y,x)
 
 `dim` returns the dimensions of a matrix or data.frame. The first value is the rows, the second is columns.
 
-#### Examples
+#### Examples {#r-basic-dim-examples}
 
 ##### How many dimensions does the data.frame `dat` have?
 
@@ -955,7 +955,7 @@ length(my_vector)
 
 `rep` is short for replicate. `rep` accepts some object, `x`, and up to three additional arguments: `times`, `length.out`, and `each`. `times` is the number of non-negative _times_ to repeat the whole object `x`. `length.out` specifies the end length you want the result to be. `rep` will repeat the values in `x` as many times as it takes to reach the provided `length.out`. `each` repeats each element in `x` the number of times specified by `each`.
 
-#### Examples
+#### Examples {#r-basic-rep-examples}
 
 ##### How do I repeat values in a vector 3 times?
 
@@ -1014,7 +1014,7 @@ rep(vec, times=rep_by)
 
 `rbind` and `cbind` append objects (vectors, matrices or data.frames) as rows (`rbind`) or as columns (`cbind`).
 
-#### Examples
+#### Examples {#r-basic-rbind-cbind-examples}
 
 ##### How do I combine 3 vectors into a matrix?
 <details>
@@ -1064,7 +1064,7 @@ dim(my_mat)
 
 `which.max` and `which.min` finds the location of the maximum and minimum, respectively, of a numeric (or logical) vector. 
 
-#### Examples
+#### Examples {#r-basic-which-examples}
 
 ##### Given a numeric vector, return the index of the maximum value. {#r-max}
 <details>
@@ -1102,7 +1102,7 @@ which(x>0, arr.ind = TRUE)
 
 `grepl` performs the same operation but rather than returning indices, returns a vector of logical `TRUE` or `FALSE` values.
 
-#### Examples
+#### Examples {#r-basic-grep-examples}
 
 ##### Given a character vector, return the index of any words ending in "s".
 <details>
@@ -1130,7 +1130,7 @@ An excellent quick reference for regular expressions. Examples using `grep` in R
 
 `sum` is a function that calculates the sum of a vector of values.
 
-#### Examples
+#### Examples {#r-basic-sum-examples}
 
 #### How do I get the sum of the values in a vector?
 
@@ -1229,7 +1229,7 @@ sqrt(var(c(1,2,NA,NaN,4), na.rm=T))
 
 `colSums` and `rowSums` calculates row and column sums for numeric matrices or data.frames. 
 
-#### Examples
+#### Examples {#r-basic-colsums-examples}
 
 #### How do I get the sum of the values for every column in a data frame?
 
@@ -1258,9 +1258,7 @@ rowSums(mtcars)
 
 `colMeans` and `rowMeans` calculates row and column means for numeric matrices or data.frames. 
 
-#### Examples
-
-#### Examples
+#### Examples {#r-basic-colmeans-examples}
 
 #### How do I get the mean for every column in a data frame?
 
@@ -1303,7 +1301,7 @@ unique(vec)
 
 `summary` shows summary statistics for a vector, or for every column in a data.frame and/or matrix. The summary statistics shown are: mininum value, maximum value, first and third quartiles, mean and median.
 
-#### Examples
+#### Examples {#r-basic-summary-examples}
 
 #### How do I get summary statistics for a vector?
 
@@ -1334,7 +1332,7 @@ summary(mtcars)
 
 `order` returns the position of each element of a vector in ascending (or descending order).
 
-#### Examples
+#### Examples {#r-basic-order-sort-examples}
 
 ##### Given a vector, arrange it in a ascending order.
 
@@ -1416,7 +1414,7 @@ paste0("abra", "kadabra", "alakazam")
 
 `tail` returns the last `n` (default is 6) parts of a vector, matrix, table, data.frame or function. 
 
-#### Examples
+#### Examples {#r-basic-head-tail-examples}
 
 ##### How do I get the first 6 rows of a data.frame?
 
@@ -1463,7 +1461,7 @@ tail(df, 8)
 df <- flights_sample
 ```
 
-#### Examples
+#### Examples {#r-basic-str-examples}
 
 ##### How do I get the number of columns or features in a data.frame?
 
@@ -1480,7 +1478,7 @@ str(df)
 
 `strsplit` accepts a vector of strings, and a vector of strings representing regular expressions. Each string in the first vector is split according to the respective string in the second vector. 
 
-#### Examples
+#### Examples {#r-basic-strsplit-examples}
 
 ##### How do I split a string containing multiple sentences into individual sentences?
 
@@ -1515,7 +1513,7 @@ strsplit(string_vec, c(" ", "\\."))
 df <- data.frame(cat_1=c(1,2,3), cat_2=c(9,8,7), ok=c(T, T, F), other=c("first", "second", "third"))
 ```
 
-#### Examples
+#### Examples {#r-basic-names-examples}
 
 ##### How do I get the column names of a data.frame?
 
@@ -1568,7 +1566,7 @@ df
 
 `prop.table` is a function that accepts the output of `table` and rather than returning counts, returns conditional proportions.
 
-#### Examples
+#### Examples {#r-basic-table-examples}
 
 ```{r, include=F}
 grades <- grades
@@ -1617,7 +1615,7 @@ prop.table(table(grades$year, grades$sex))
 
 You can find more useful information by running `?cut.POSIXt`.
 
-#### Examples
+#### Examples {#r-basic-cut-examples}
 
 ```{r, include=F}
 times <- seq(as.POSIXct("2020-06-01 06:00"), by = "1 month", length.out = 24)
@@ -1788,7 +1786,7 @@ tail(sort(tapply(mymidwestDF$TRANSACTION_AMT, mymidwestDF$NAME, sum)))
 
 The function `difftime` computes/creates a time interval between two dates/times and converts the interval to a chosen time unit.
 
-#### Examples
+#### Examples {#r-basic-difftime-examples}
 
 ##### How many days,hours and minutes are there between the dates `2015-04-06` and `2015-01-01`?
 
@@ -1922,7 +1920,7 @@ authors <- data.frame(
 )
 ```
 
-#### Examples
+#### Examples {#r-basic-merge-examples}
 
 Consider the data.frame's `books` and `authors`:
 
@@ -2045,7 +2043,7 @@ row.names(df) <- c("row1", "row2", "row3")
 df[c("row1", "row3"),c("cat_1", "ok")]
 ```
 
-#### Examples
+#### Examples {#r-data-frame-examples}
 
 ```{r, include=F}
 df <- data.frame(cat_1=c(1,2,3), cat_2=c(9,8,7), ok=c(T, T, F), other=c("first", "second", "third"))
@@ -2127,7 +2125,7 @@ df[, grep("^cat_", names(df))]
 
 ## Reading & Writing data {#r-reading-and-writing-data}
 
-### Examples
+### Examples {#r-reading-and-writing-data-examples}
 
 #### How do I read a csv file called `grades.csv` into a data.frame? {#r-read}
 
@@ -2300,7 +2298,7 @@ For loops allow us to execute similar code over and over again until we've loope
 
 Using the suite of apply functions is more common in R. It is often said that the apply suite of function are much faster than for loops in R. While this used to be the case, this is no longer true. 
 
-#### Examples
+#### Examples {#r-for-loops-examples}
 
 ##### How do I loop through every value in a vector and print the value?
 
@@ -2492,7 +2490,7 @@ my_list <- list(
 
 The `lapply` is a function that applies a function `FUN` to each element in a vector or list, and returns a list.
 
-#### Examples
+#### Examples {#r-lapply-examples}
 
 ##### How do I get the mean value of each vector in our list, `my_list`, in another list? 
 
@@ -2657,7 +2655,7 @@ but this is all accomplished by the 1-line `lapply` that we did earlier, in a mu
 
 If you recall, when accessing an element in a list using single brackets `my_list[1]`, the result will always return a list. If you access an element with double brackets `my_list[[1]]`, `R` will attempt to simplify the result. This is analogous to `lapply` and `sapply`.
 
-#### Examples
+#### Examples {#r-sapply-examples}
 
 ##### How do I get the mean value of each vector in our list, `my_list`, but rather than the result being a list, put the results in the simplest form?
 
@@ -2721,7 +2719,7 @@ If your `function` (in this case _mean_), requires extra arguments, you can pass
 tapply(grades$grade, grades$year, mean, na.rm=T)
 ```
 
-#### Examples
+#### Examples #{r-tapply-examples}
 
 ##### Amazon fine food tapply example {#r-Amazon-tapply-example}
 
@@ -2866,7 +2864,7 @@ dims(xyz=grades, abc=my_mat, sort=T)
 
 Here, `dims` accepts any number of data.frame-like objects, `...`, and a logical value indicating whether or not to sort the list by names. As you can see, if arguments are passed to `dims` with names, those names can be accessed within `dims` via `names(list(...))`. 
 
-### Examples
+### Examples {#r-writing-functions-examples}
 
 #### Create a function named `should_be_transformed` that, given a value, returns `TRUE` if the value is "t", and `FALSE` if the value is "f", and NA otherwise. 
 
@@ -3758,7 +3756,7 @@ register_google(key="mQkzTpiaLYjPqXQBotesgif3EfGL2dbrNVOrogg", write=TRUE)
 
 Note that if you choose option (2), your API key will be saved within your `~/.Renviron`.
 
-#### Examples
+#### Examples {#r-ggmap-examples}
 
 ##### How do I get a map of West Lafayette?
 
@@ -3800,7 +3798,7 @@ ggmap(map) + geom_point(data = points_to_add, aes(x = longitude, y = latitude))
 
 `leaflet` is a popular JavaScript library to create interactive maps. The `leaflet` R package makes it easy to create incredible interactive maps.
 
-#### Examples
+#### Examples {#r-leaflet-examples}
 
 ##### How do I plot some longitude and latitude points on an interactive map? {#r-leaflet-example01}
 
@@ -4033,7 +4031,7 @@ stringr::str_extract(text, ".*at.*")
 ```
 One final note is that you must double-escape certain characters in patterns because R treats backslashes as escape values for character constants ([stackoverflow](https://stackoverflow.com/questions/27721008/how-do-i-deal-with-special-characters-like-in-my-regex)). For example, to write `\(` we must first escape the `\`, so we write `\\(`. This is true for many character which would normally only be preceded by a single `\`.
 
-#### Examples
+#### Examples {#r-str-extract-examples}
 
 ##### How can I extract the text between parenthesis in a vector of texts?
 <details>
@@ -4112,7 +4110,7 @@ year(my_date)
 
 `strrep` is a function that allows you to repeat the characters a given number of times.
 
-#### Examples
+#### Examples {#r-strrep-examples}
 
 ##### How to repeat the string of characters ABC three times?
 
@@ -4136,7 +4134,7 @@ strrep(c("A", "B", "C"), c(2,3,4))
 
 `nchar` is a function which counts the number of characters and symbols in a word or a string. Punctuation and blank spaces are counted as well.
 
-#### Examples
+#### Examples {#r-nchar-examples}
 
 ##### How to to find the number of characters and or symbols the word "Protozoa"?
 

--- a/06-python.Rmd
+++ b/06-python.Rmd
@@ -642,7 +642,7 @@ The following is a table of list methods from [w3schools.com](https://www.w3scho
 |reverse()|Reverses the order of the list|
 |sort()|Sorts the list|
 
-#### Examples
+#### Examples {#p-list-methods-examples}
 
 Let's start by creating a couple of lists:
 
@@ -1486,7 +1486,7 @@ To use the `csv` module, simply import it:
 import csv
 ```
 
-#### Examples
+#### Examples {#p-csv-pkg-examples}
 
 ##### How do you print each row of a csv `flights_sample.csv`?
 
@@ -1536,7 +1536,7 @@ with open('grades_semi.csv') as my_csv_file:
 
 ### `Path` {#p-pathlib-path}
 
-#### Examples
+#### Examples {#p-pathlib-examples}
 
 ##### How do I get the size of a file in bytes? Megabytes? Gigabytes?
 
@@ -1561,7 +1561,7 @@ print(f'Size in gigabytes: {size_in_bytes/1_000_000_000}')
 
 `read_csv` is a function from the `pandas` library that allows you to read tabular data into a `pandas` DataFrame.
 
-#### Examples
+#### Examples {#p-pandas-read_csv-examples}
 
 ##### How do I read a csv file called `grades.csv` into a DataFrame? 
 
@@ -1639,7 +1639,7 @@ final_result
 
 `to_csv` is a function from the `pandas` library that allows you to write/save a `pandas` DataFrame into a csv file on your computer.
 
-#### Examples
+#### Examples {#p-pandas-to_csv-examples}
 
 ##### How do I save the pandas DataFrame called `myDF` as a cvs file called `grades.csv` in my scratch directory? 
 
@@ -1661,7 +1661,7 @@ The DataFrame is one of the primary classes used from the `pandas` package. Much
 
 Most operations involve [reading a dataset into a DataFrame](#p-pandas-read_csv), accessing the DataFrame's attributes, and using the DataFrame's methods to perform operations on the underlying data or with other DataFrames.
 
-#### Examples
+#### Examples {#p-p-pandas-dataframe-examples}
 
 ##### How do I get the number of rows and columns of a DataFrame, `myDF`?
 
@@ -2043,7 +2043,7 @@ print(response)
 
 For simpler tasks, using `requests` to scrape the data, and a package like `lxml` or `beautifulsoup4` to parse the data, is appropriate.
 
-#### Examples
+#### Examples {#p-requests-examples}
 
 ##### How do I scrape the HTML from https://datamine.purdue.edu/? {#p-requests-example01}
 
@@ -2114,7 +2114,7 @@ firefox_options.binary_location = '/class/datamine/apps/firefox/firefox'
 driver = webdriver.Firefox(options=firefox_options, executable_path='/class/datamine/apps/geckodriver')
 ```
 
-#### Examples
+#### Examples {#p-selenium-examples}
 
 ##### How do I scrape a website using `selenium`?
 
@@ -2508,7 +2508,7 @@ tree = etree.parse("example.xml")
 
 From there, you can use [xpath expressions](#xml-xpath) to parse the dataset.
 
-#### Examples
+#### Examples {#p-lxml-examples}
 
 ##### How do I load a webpage I scraped using `requests` into an `lxml` tree?
 


### PR DESCRIPTION
Fixes #85 

### Explanation

Each of these subsections had the automatically generated reference of "examples" - visiting the page at a `#examples` would therefore bring you to the first `Examples` section - right now, it's here

https://thedatamine.github.io/the-examples-book/data-formats.html#examples

this updates every `Examples` section with a unique link, following the format

`#$PARENTLINK-examples`

e.g.

```
## Section {#some-section}
### Examples {#some-section-examples}
```

### Note
There are _probably_ other sections that are broken for the same reason, but it would be a larger effort to find any duplicate section titles - this probably warrants a new ticket.