### PR TITLE
quick fix of project 8 numbering

### DIFF
--- a/09-projects.Rmd
+++ b/09-projects.Rmd
@@ -1575,7 +1575,7 @@ type(my_variable)
 
 ---
 
-### Project 7 {#p08-190}
+### Project 8 {#p08-190}
 
 ---
 


### PR DESCRIPTION
Dear @kevinamstutz  a student just pointed out the fact that project 8 was titled project 7 in the example book. This is a quick fix for that before I complete the full review of the project.