### PR TITLE
Update printing-and-f-strings.adoc

### DIFF
--- a/content/modules/python/pages/printing-and-f-strings.adoc
+++ b/content/modules/python/pages/printing-and-f-strings.adoc
@@ -112,7 +112,7 @@ print("You can also tab!\tHow about two tabs?\t\tYou bet!")
 You can also tab!   How about two tabs?     You bet!
 ----
 
-Now that we know how Python recognizes some of these characters, what do you do if you actually want to print `\n` or `\t? Thankfully we have a couple options: 
+Now that we know how Python recognizes some of these characters, what do you do if you actually want to print `\n` or `\t`? Thankfully we have a couple options: 
 
 [source, python]
 ----
@@ -306,7 +306,7 @@ My float 000444.444
 
 Note that in this case the first `0` means "zero pad", and the following `10` represents the total width of the result. In this case it means zero pad until the full number takes up 10 characters (including the decimal place).
 
-For floats specifically it can be helpful to think of the f-string format as `f'{value:{width}.{precision}}`. An overview of f-strings is included in the <<resource, Resources>> section at the bottom of the page.
+For floats specifically it can be helpful to think of the f-string format as `f'{value:{width}.{precision}}`. An overview of f-strings is included in the <<Resources, Resources>> section at the bottom of the page.
 
 This can be helpful is you have several numbers that you want to have the same format: 
 


### PR DESCRIPTION
Minor formatting fixes on the Python f-strings page. Adding a ` and fixing the Resources link.