### PR TITLE
Small fix to `__init__.py`

### DIFF
--- a/projects-appendix/modules/current-projects/pages/30100-2022-project09.adoc
+++ b/projects-appendix/modules/current-projects/pages/30100-2022-project09.adoc
@@ -239,7 +239,7 @@ import imdb
 from imdb import get_rating
 ----
 
-Finally, copy and paste your `get_rating` function into a new file called `imdb.py`, and drop `imdb.py` into `$HOME/tdm-drward/imdb` (or your equivalent package path). In addition, create another new file called `__init__.py` in the same directory. Leave it blank for now. 
+Finally, copy and paste your `get_rating` function into a new file called `imdb.py`, and drop `imdb.py` into `$HOME/tdm-drward/imdb` (or your equivalent package path). In addition, create another new file called `\\__init__.py` in the same directory. Leave it blank for now. 
 
 [TIP]
 ====


### PR DESCRIPTION
Just wanted to add "\\\\" to the `__init__.py` mention in line 242. Asciidoc doesn't like dunder methods and italicizes all of them if "\\\\" isn't prepended to them. Hope it's not a bother! I was doing the project myself and didn't want people to possibly name the file the wrong thing