### PR TITLE
Changed office hours zoom meeting link

### DIFF
--- a/projects-appendix/modules/fall2025/pages/office_hours.adoc
+++ b/projects-appendix/modules/fall2025/pages/office_hours.adoc
@@ -6,7 +6,7 @@ Office hours before 5 PM on weekdays (Monday through Friday) will be offered bot
 
 Office hours on Sundays (all day) and also on weekdays after 5 PM will be held exclusively virtually.
 
-Office Hours Zoom Link: https://purdue-edu.zoom.us/s/97774213087
+Office Hours Zoom Link: https://purdue-edu.zoom.us/s/94769789043
 
 Checklist for the Zoom Link:
 


### PR DESCRIPTION
New TAs did not have host privileges on the old zoom meeting link, so it prevented them from allowing students to share their screens. I created a new zoom meeting link and gave all office hours TAs host privileges. I also gave Dr. Ward and Stacey Dunderman host permissions as well.