### PR TITLE
Changing OH Zoom Link Again due to issues with students being prevent…

### DIFF
--- a/projects-appendix/modules/fall2025/pages/office_hours.adoc
+++ b/projects-appendix/modules/fall2025/pages/office_hours.adoc
@@ -6,7 +6,7 @@ Office hours before 5 PM on weekdays (Monday through Friday) will be offered bot
 
 Office hours on Sundays (all day) and also on weekdays after 5 PM will be held exclusively virtually.
 
-Office Hours Zoom Link: https://purdue-edu.zoom.us/s/94769789043
+Office Hours Zoom Link: https://purdue-edu.zoom.us/j/97199764245?pwd=bTMbApvj5ajczPimat5TbakdVEDaeK.1
 
 Checklist for the Zoom Link:
 


### PR DESCRIPTION
…ed from joining

The new meeting I created earlier did not allow students to join, only TAs. I had to create a new meeting and make the settings so that the students could join the meeting as well